### PR TITLE
Compatibility for V12

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,7 +28,7 @@
 	"styles": [
 		"./styles/gridStyle.css"
 	],
-	"url": "https://github.com/TheGoodwin/scaleGrid/",
-	"manifest": "https://raw.githubusercontent.com/TheGoodwin/scaleGrid/feature/compatibility-v12/module.json",
-	"download": "https://github.com/TheGoodwin/scaleGrid/archive/refs/heads/feature/compatibility-v12.zip"
+	"url": "https://github.com/atomdmac/scaleGrid/",
+	"manifest": "https://raw.githubusercontent.com/atomdmac/scaleGrid/master/module.json",
+	"download": "https://github.com/atomdmac/scaleGrid/archive/refs/tags/v1.4.4.zip"
 }

--- a/module.json
+++ b/module.json
@@ -1,8 +1,8 @@
 {
-	"id": "scaleGrid",
-	"title": "Grid Scaler",
+	"id": "theGoodwinScaleGrid",
+	"title": "TheGoodwin's Grid Scaler",
 	"description": "A set of tools to quickly match the scene grid to your map's grid. Works with both squares and hexes.",
-	"version": "1.4.4",
+	"version": "1.4.5",
 	"compatibility": {
 		"minimum": 10,
 		"verified": "11"
@@ -17,6 +17,9 @@
 		},
 		{
 			"name": "atomdmac"
+		},
+		{
+			"name": "TheGoodwin"
 		}
 	],
 	"esmodules": [
@@ -25,7 +28,7 @@
 	"styles": [
 		"./styles/gridStyle.css"
 	],
-	"url": "https://github.com/atomdmac/scaleGrid/",
-	"manifest": "https://raw.githubusercontent.com/atomdmac/scaleGrid/master/module.json",
-	"download": "https://github.com/atomdmac/scaleGrid/archive/refs/tags/v1.4.4.zip"
+	"url": "https://github.com/TheGoodwin/scaleGrid/",
+	"manifest": "https://raw.githubusercontent.com/TheGoodwin/scaleGrid/feature/compatibility-v12/module.json",
+	"download": "https://github.com/TheGoodwin/scaleGrid/archive/refs/tags/v1.4.5.zip"
 }

--- a/module.json
+++ b/module.json
@@ -1,11 +1,11 @@
 {
-	"id": "theGoodwinScaleGrid",
-	"title": "TheGoodwin's Grid Scaler",
+	"id": "scaleGrid",
+	"title": "Grid Scaler",
 	"description": "A set of tools to quickly match the scene grid to your map's grid. Works with both squares and hexes.",
 	"version": "1.4.5",
 	"compatibility": {
 		"minimum": 10,
-		"verified": "11"
+		"verified": "12"
 	},
 	"authors": [
 		{

--- a/module.json
+++ b/module.json
@@ -30,5 +30,5 @@
 	],
 	"url": "https://github.com/TheGoodwin/scaleGrid/",
 	"manifest": "https://raw.githubusercontent.com/TheGoodwin/scaleGrid/feature/compatibility-v12/module.json",
-	"download": "https://github.com/TheGoodwin/scaleGrid/archive/refs/tags/v1.4.5.zip"
+	"download": "https://github.com/TheGoodwin/scaleGrid/archive/refs/heads/feature/compatibility-v12.zip"
 }

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -95,24 +95,28 @@ class ScaleGridLayer extends CanvasLayer {
           icon: "fas fa-square",
           name: "DrawGridTool",
           title: "Set grid by drawing either a square or hexagon",
+          button: true,
           onClick: gridScaler.setupDrawGrid
         },
         {
           icon: "fas fa-th",
           name: "Draw3x3Tool",
           title: "Set grid by drawing a 3x3 box",
+          button: true,
           onClick: gridScaler.setupDraw3X3
         },
         {
           icon: "fas fa-ruler-horizontal",
           name: "AdjustXTool",
           title: "Set the X position of the grid",
+          button: true,
           onClick: gridScaler.setupAdjustX
         },
         {
           icon: "fas fa-ruler-vertical",
           name: "AdjustYTool",
           title: "Set the Y position of the grid",
+          button: true,
           onClick: gridScaler.setupAdjustY
         },
         {
@@ -236,12 +240,14 @@ class ScaleGridLayer extends CanvasLayer {
   // <================== Start Setup Functions  ====================>
 
   setupAdjustX() {
+    ui.notifications.info("Click on a point to set up the X position of your grid");
     console.log("Grid Scale | Drawing Layer | Running AdjustX")
     gridScaler.currentTool = "AdjustXTool"
     gridScaler.addListeners();
   }
 
   setupAdjustY() {
+    ui.notifications.info("Click on a point to set up the Y position of your grid");
     console.log("Grid Scale | Drawing Layer | Running AdjustY")
     gridScaler.currentTool = "AdjustYTool"
     gridScaler.addListeners();
@@ -258,16 +264,19 @@ class ScaleGridLayer extends CanvasLayer {
   }
 
   setupDrawSquare() {
+    ui.notifications.info("Click and drag your mouse to draw a square");
     gridScaler.currentTool = "DrawSquareTool"
     gridScaler.initializeDrawGrid();
   }
 
   setupDrawHex() {
+    ui.notifications.info("Click and drag your mouse to draw an hexagon");
     gridScaler.currentTool = "DrawHexTool"
     gridScaler.initializeDrawGrid();
   }
 
   setupDraw3X3() {
+    ui.notifications.info("Click and drag your mouse to draw a box of 3 squares");
     gridScaler.currentTool = "Draw3x3Tool"
     gridScaler.initializeDrawGrid();
   }

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -950,6 +950,8 @@ class ScaleGridLayer extends CanvasLayer {
   // Save the color and alpha of the current scene's grid.
   // We'll use this to reset it when the preview is toggled off. 
   saveGridSettings(sceneId) {
+    log(canvas.grid)
+
     gridScaler.cavasGridTempSettings[sceneId] = {
       visible: canvas.grid.visible,
       alpha: canvas.grid.grid.options.alpha,

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -119,12 +119,14 @@ class ScaleGridLayer extends CanvasLayer {
           icon: "fas fa-object-group",
           name: "MoveGridTool",
           title: "Move and scale the grid",
+          button: true,
           onClick: gridScaler.openGridMoveDialog
         },
         {
           icon: 'fas fa-pen-square',
           name: "ManualGridSizeTool",
           title: "Set the grid by number of squares or hexes",
+          button: true,
           onClick: gridScaler.openGridSizeDialog
         },
         {

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -426,9 +426,9 @@ class ScaleGridLayer extends CanvasLayer {
 
     switch (gridType) {
       case 1:
-        const closeTopL = canvas.grid.getTopLeft(mousePos.x, mousePos.y);
-        const oppX = closeTopL[0] + gridSize;
-        const absTopL = Math.abs(closeTopL[0] - mousePos.x);
+        const closeTopL = canvas.grid.getTopLeftPoint({ x: mousePos.x, y: mousePos.y });
+        const oppX = closeTopL.x + gridSize;
+        const absTopL = Math.abs(closeTopL.x - mousePos.x);
         const absTopR = Math.abs(oppX - mousePos.x);
 
         if (absTopL > absTopR) {
@@ -484,9 +484,9 @@ class ScaleGridLayer extends CanvasLayer {
 
     switch (gridType) {
       case 1:
-        const closeTopL = canvas.grid.getTopLeft(mousePos.x, mousePos.y);
-        const oppY = closeTopL[1] + gridSize;
-        const absTop = Math.abs(closeTopL[1] - mousePos.y);
+        const closeTopL = canvas.grid.getTopLeftPoint({ x: mousePos.x, y: mousePos.y });
+        const oppY = closeTopL.y + gridSize;
+        const absTop = Math.abs(closeTopL.y - mousePos.y);
         const absBot = Math.abs(oppY - mousePos.y);
 
         if (absTop < absBot) {

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -5,7 +5,7 @@ import {
 /*
 **How to work with Foundry grids, a primer**
 
-When working on the grid, you generally want to access 'canvas.grid.grid'. That's going to be
+When working on the grid, you generally want to access 'canvas.grid'. That's going to be
 a different object depending on which type of grid is currently selected; SquareGrid, HexagonalGrid,
 or BaseGrid (gridless). 'canvas.grid' is the GridLayer, which we don't deal with here.
 
@@ -17,8 +17,8 @@ DIMENSIONS
 The scene grid is split into outer and inner panels, with the inner panel set inside and offset 
 from the outer panel (usually centered).
 
-- 'canvas.grid.grid.options' to get the dimensions and other information about the grid
-- 'canvas.dimensions' is a shortcut for 'canvas.grid.grid.options.dimensions'
+- 'canvas.grid.options' to get the dimensions and other information about the grid
+- 'canvas.dimensions' is a shortcut for 'canvas.grid.options.dimensions'
 
 Properties (v10):
   - alpha: 0.45
@@ -839,7 +839,7 @@ class ScaleGridLayer extends CanvasLayer {
     return setInterval(() => {
       const sceneX = canvas.dimensions.sceneX;
       const sceneY = canvas.dimensions.sceneY;
-      const snapPos = canvas.grid.grid.getSnappedPosition(sceneX, sceneY);
+      const snapPos = canvas.grid.getSnappedPoint(new PIXI.Point(sceneX, sceneY), { mode: CONST.GRID_SNAPPING_MODES.CENTER });
 
       gridUtils.refreshGrid({ background: true, offsetX: 0, offsetY: 0, offsetSize: gridOffset })
 
@@ -862,7 +862,7 @@ class ScaleGridLayer extends CanvasLayer {
   }
 
   refreshGridForResize(oldSnapPos, extraOffset) {
-    const newSnapPos = canvas.grid.grid.getSnappedPosition(canvas.dimensions.sceneX, canvas.dimensions.sceneY);
+    const newSnapPos = canvas.grid.getSnappedPoint(new PIXI.Point(canvas.dimensions.sceneX, canvas.dimensions.sceneY), { mode: CONST.GRID_SNAPPING_MODES.CENTER });
     const gridOffsetX = newSnapPos.x - oldSnapPos.x + extraOffset;
     const gridOffsetY = newSnapPos.y - oldSnapPos.y + extraOffset;
 

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -140,6 +140,7 @@ class ScaleGridLayer extends CanvasLayer {
           icon: "fas fa-undo",
           name: "ResetGridTool",
           title: "Reset the grid",
+          button: true,
           onClick: e => {
             this.resetDialog(e);
           }

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -129,8 +129,9 @@ class ScaleGridLayer extends CanvasLayer {
         },
         {
           icon: 'fas fa-border-none',
-          name: "ToogleGridTool",
+          name: "ToggleGridTool",
           title: "Toggle the grid display temporarily",
+          toggle: true,
           onClick: gridScaler.toggleGrid
         },
         {

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -950,12 +950,10 @@ class ScaleGridLayer extends CanvasLayer {
   // Save the color and alpha of the current scene's grid.
   // We'll use this to reset it when the preview is toggled off. 
   saveGridSettings(sceneId) {
-    log(canvas.grid)
-
     gridScaler.cavasGridTempSettings[sceneId] = {
       visible: canvas.grid.visible,
-      alpha: canvas.grid.grid.options.alpha,
-      color: canvas.grid.grid.options.color
+      alpha: canvas.grid.grid.alpha,
+      color: canvas.grid.grid.color
     };
   }
 

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -951,9 +951,9 @@ class ScaleGridLayer extends CanvasLayer {
   // We'll use this to reset it when the preview is toggled off. 
   saveGridSettings(sceneId) {
     gridScaler.cavasGridTempSettings[sceneId] = {
-      visible: canvas.grid.visible,
-      alpha: canvas.grid.grid.alpha,
-      color: canvas.grid.grid.color
+      visible: GridLayer.instance.visible,
+      alpha: GridLayer.instance.alpha,
+      color: GridLayer.instance.color
     };
   }
 

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,17 +147,11 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      canvas.interface.grid.draw({
+      canvas.interface.grid.initializeMesh({
         dimensions: d,
         color: Color.fromString(color.toString().replace("#", "0x")),
         alpha: alpha
       });
-
-      /** canvas.grid.grid.draw({
-        dimensions: d,
-        color: color.replace("#", "0x"),
-        alpha: alpha
-      }); **/
 
       canvas.stage.hitArea = d.rect;
     }

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,7 +147,7 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      canvas.dimensions = d;
+      //canvas.dimensions = d;
       canvas.grid.grid.color = color.replace("#", "0x");
       canvas.grid.grid.alpha = alpha;
       /** canvas.grid.grid.draw({

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -20,7 +20,7 @@ export class gridUtils {
       // Older Foundry versions use the first case, newer versions (>v11) use the second.
       const interaction = canvas.app?.plugins?.interaction || canvas.app?.renderer?.plugins?.interaction;
       // Older versions of Foundry use mouse, newer versions (>v10) use pointer
-      const pointer = interaction.mouse || interaction.pointer;
+      const pointer = interaction?.mouse || interaction?.pointer || canvas.app.renderer.events.pointer;
       result = pointer.getLocalPosition(canvas.app.stage);
     }
 

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,7 +147,7 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      GridLayer.draw({
+      canvas.interface.grid.draw({
         dimensions: d,
         color: color.replace("#", "0x"),
         alpha: alpha

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,7 +147,7 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      GridLayer.instance.draw({
+      GridLayer.draw({
         dimensions: d,
         color: color.replace("#", "0x"),
         alpha: alpha

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -149,7 +149,7 @@ export class gridUtils {
     if (grid) {
       canvas.interface.grid.draw({
         dimensions: d,
-        color: color.replace("#", "0x"),
+        color: color.fromString(color.toString().replace("#", "0x")),
         alpha: alpha
       });
 

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -149,7 +149,7 @@ export class gridUtils {
     if (grid) {
       canvas.interface.grid.draw({
         dimensions: d,
-        color: color.fromString(color.toString().replace("#", "0x")),
+        color: Color.fromString(color.toString().replace("#", "0x")),
         alpha: alpha
       });
 

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,9 +147,12 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      //canvas.dimensions = d;
-      canvas.grid.grid.color = color.replace("#", "0x");
-      canvas.grid.grid.alpha = alpha;
+      GridLayer.instance.draw({
+        dimensions: d,
+        color: color.replace("#", "0x"),
+        alpha: alpha
+      });
+
       /** canvas.grid.grid.draw({
         dimensions: d,
         color: color.replace("#", "0x"),

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -108,9 +108,9 @@ export class gridUtils {
     offsetY = null,
     offsetSize = null, // can't be smaller than 50
     alpha = 1.0,
-    color = "#FF0000"} = {}) {
+    color = "#FF0000" } = {}) {
 
-    const d = canvas.grid.grid.options.dimensions;
+    const d = canvas.dimensions;
 
     if (offsetSize) {
       d.size += offsetSize;

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,11 +147,14 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      canvas.grid.grid.draw({
+      canvas.dimensions = d;
+      canvas.grid.grid.color = color.replace("#", "0x");
+      canvas.grid.grid.alpha = alpha;
+      /** canvas.grid.grid.draw({
         dimensions: d,
         color: color.replace("#", "0x"),
         alpha: alpha
-      });
+      }); **/
 
       canvas.stage.hitArea = d.rect;
     }

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,11 +147,12 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      canvas.interface.grid.initializeMesh({
+      canvas.interface.grid.mesh.initialize({
         dimensions: d,
+        size: d.size,
         color: Color.fromString(color.toString().replace("#", "0x")),
         alpha: alpha
-      });
+      })
 
       canvas.stage.hitArea = d.rect;
     }


### PR DESCRIPTION
- Fix the compatiblity with Foundry V12 for all buttons
- The toggle grid display button is now a toggle button
- All of the other buttons were made actual buttons. There are no need to select another tool to disable them anymore and a notification appears to make it clearer how to they work.
    - Draw a square or hexagon button
    - Draw a 3x3 box button
    - Set the X position of the grid button
    - Set the Y position of the grid button
    - Move and scale the grid button
    - Set the grid by number of squares and hexes
    - Reset the grid